### PR TITLE
browser-to-bearer middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ middelware to work correctly. In theory this middleware can work with any
 OAuth2 middleware, but the below example is using the `@curveball/oauth2`
 middleware.
 
+In addition to a working OAuth2 middleware, it also requires a `session`
+middleware.
+
 ```typescript
 import { Application } from '@curveball/core';
 import oauth2 from '@curveball/oauth2';
 import browserToBearer from '@curveball/browser-to-bearer';
-
+import session from '@curveball/session';
 
 const app = new Application();
+
+app.use(session());
 
 app.use(browserToBearer({
   authorizeEndpoint: 'https://auth.example.org/authorize',

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ import browserToBearer from '@curveball/browser-to-bearer';
 const app = new Application();
 
 app.use(browserToBearer({
-  authorizeEndpoint: 'http://auth.example.org/authorize',
-  tokenEndpoint: 'http://auth.example.org/token',
+  authorizeEndpoint: 'https://auth.example.org/authorize',
+  tokenEndpoint: 'https://auth.example.org/token',
   clientId: 'some_client_id',
   clientSecret: 'some_client_secret',
-  publicUri: 'http://resource-server.example.org/', // where to redirect back to
+  publicUri: 'https://resource-server.example.org/', // where to redirect back to
   scope: [], // List of OAuth2 scopes
 });
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,57 @@
-Curveball New Package
-=====================
+Curveball browser-to-bearer
+===========================
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/curveballjs/new-package.svg)](https://greenkeeper.io/)
+This package contains a [Curveball][1] middleware that allows a user with a
+regular browser to log into an API that's an OAuth2 resource server.
 
-This repository serves as the skeleton for all new [Curveball][1] packages.
+It will do so by intercepting HTTP `401 Unauthorized` errors, seeing if the
+user wanted `Accept: text/html` and redirect the user to an OAuth2
+authorization endpoint.
+
+After the user comes back, the access token gets validated and placed into a
+cookie. This cookie is then converted to an `Authorization` header, which
+will make it seem to the resource server that the user has normal OAuth2
+authorization information.
+
+What this enables in a nutshell is allowing developers to browse OAuth2 APIs
+with a browser, which otherwise is pretty hard to do.
+
 
 Installation
 ------------
 
-    npm install @curveball/new-package 
+    npm install @curveball/browser-to-bearer
 
 
 Getting started
 ---------------
 
-...
+This middleware needs to be loaded *before* your normal authorization
+middelware to work correctly. In theory this middleware can work with any
+OAuth2 middleware, but the below example is using the `@curveball/oauth2`
+middleware.
 
-API
----
+```typescript
+import { Application } from '@curveball/core';
+import oauth2 from '@curveball/oauth2';
+import browserToBearer from '@curveball/browser-to-bearer';
 
-...
 
-[1]: https://github.com/curveballjs/
+const app = new Application();
+
+app.use(browserToBearer({
+  authorizeEndpoint: 'http://auth.example.org/authorize',
+  tokenEndpoint: 'http://auth.example.org/token',
+  clientId: 'some_client_id',
+  clientSecret: 'some_client_secret',
+  publicUri: 'http://resource-server.example.org/', // where to redirect back to
+  scope: [], // List of OAuth2 scopes
+});
+
+app.use(oauth2({
+  introspectionEndpoint: 'https://auth.example.org/introspect'
+});
+```
+
+
+[1]: https://github.com/curveball/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@curveball/new-package",
+  "name": "@curveball/browser-to-bearer",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -192,6 +192,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
       "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==",
       "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.3.tgz",
+      "integrity": "sha512-X3TNlzZ7SuSwZsMkb5fV7GrPbVKvHc2iwHmslb8bIxRKWg2iqkfm3F/Wd79RhDpOXR7wCtKAwc5Y2JE6n/ibyw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/sinon": {
       "version": "7.5.0",
@@ -720,9 +729,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -1373,6 +1382,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2066,16 +2080,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
   },
   "homepage": "https://github.com/curveballjs/browser-to-bearer#readme",
   "devDependencies": {
+    "@curveball/core": "^0.9.0",
     "@types/chai": "^4.2.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.6",
+    "@types/node-fetch": "^2.5.3",
     "@types/sinon": "^7.5.0",
     "chai": "^4.2.0",
     "mocha": "^6.2.2",
@@ -45,8 +47,7 @@
     "sinon": "^7.5.0",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.1",
-    "typescript": "^3.7.2",
-    "@curveball/core": "^0.9.0"
+    "typescript": "^3.7.2"
   },
   "types": "dist/",
   "nyc": {
@@ -56,5 +57,8 @@
   },
   "peerDependencies": {
     "@curveball/core": "^0.9.0"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,176 @@
-/* tslint:disable */
-console.log('Hello world!');
+import { Context, Middleware } from '@curveball/core';
+import { BadRequest, Forbidden, Unauthorized } from '@curveball/http-errors';
+import fetch from 'node-fetch';
+import querystring from 'querystring';
+
+type OAuth2Options = {
+  authorizeEndpoint: string,
+  clientId: string,
+  clientSecret: string,
+  publicUri: string,
+  scope: string[],
+  tokenEndpoint: string,
+};
+
+/**
+ * This middleware allows OAuth2 bearer tokens to be specified as cookies.
+ *
+ * If authentication fails, and we detect a browser, this middleware will
+ * automatically attempt to do OAuth2 authentication.
+ */
+export default function(options: OAuth2Options): Middleware {
+
+  return async (ctx, next) => {
+
+    if (ctx.request.headers.has('Authorization')) {
+      // If there already was an Authorization header, use that.
+      return next();
+    }
+
+    if (ctx.path === '/_browser_auth') {
+      return handleOAuth2Code(ctx, options);
+    }
+
+    const oauth2Tokens = await getOAuth2Tokens(ctx, options);
+    if (!oauth2Tokens) {
+      // No active tokens
+      return handleInnerRequest(ctx, next, options);
+    }
+
+    if (!['GET', 'HEAD', 'OPTIONS'].includes(ctx.method)) {
+      // For now we only support safe methods.
+      throw new Forbidden('When using cookie-based authentication, only safe methods are supported');
+    }
+
+    ctx.request.headers.set('Authorization', 'Bearer ' + oauth2Tokens.accessToken);
+    return handleInnerRequest(ctx, next, options);
+
+  };
+
+}
+
+async function handleInnerRequest(ctx: Context, next: () => void | Promise<void> , options: OAuth2Options) {
+
+  try {
+    await next();
+  } catch (e) {
+    if (e instanceof Unauthorized) {
+      const state = ctx.path;
+      const authUrl = getAuthUrl(options, state);
+      ctx.response.headers.append('Link', '<' + authUrl + '>; rel="authenticate"');
+    }
+    throw e;
+
+  }
+
+}
+
+/**
+ * This route gets called for the /_browser_auth endpoint.
+ *
+ * This endpoint is what a user gets redirected to by the OAuth2 server, after
+ * a successful or failed login.
+ *
+ * https://tools.ietf.org/html/rfc6749#section-4.1.2
+ */
+async function handleOAuth2Code(ctx: Context, options: OAuth2Options) {
+
+  if (ctx.query.error) {
+    throw new Error('Error from OAuth2 server: ' + ctx.query.error);
+  }
+
+  if (!ctx.query.code) {
+    throw new BadRequest('A "code" query parameter was expected');
+  }
+  const code = ctx.query.code;
+  const params = {
+    grant_type: 'authorization_code',
+    code: code,
+    redirect_uri: options.publicUri,
+    client_id: options.clientId
+  };
+
+  const response = await fetch(options.tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Basic ' + Buffer.from(options.clientId + ':' + options.clientSecret).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: querystring.stringify(params),
+  });
+  if (!response.ok) {
+    throw new Error('Received HTTP error when validating authentication code on OAuth2 server: ' + response.status);
+  }
+  const rBody = await response.json();
+
+  ctx.response.status = 303;
+  ctx.state.session.oauth2tokens = {
+    accessToken: rBody.access_token,
+    expires: Date.now() + (rBody.expires_in * 1000),
+    refreshToken: rBody.refresh_token,
+  };
+  const state = ctx.query.state || '/';
+  if (!state.startsWith('/') || state.startsWith('//')) {
+    throw new Error('Sandbox violation');
+  }
+  ctx.response.headers.set('Location', state);
+
+}
+type OAuth2Token = {
+  accessToken: string,
+  expires: number,
+  refreshToken: string,
+};
+
+async function getOAuth2Tokens(ctx: Context, options: OAuth2Options): Promise<OAuth2Token | null> {
+
+  if (!ctx.state.session.oauth2tokens) {
+    return null;
+  }
+
+  const token: OAuth2Token = ctx.state.session.oauth2tokens;
+
+  if (token.expires > Date.now()) {
+    return token;
+  }
+
+  // Attempt to refresh token
+  const params = {
+    grant_type: 'refresh_token',
+    refresh_token: token.refreshToken,
+    client_id: options.clientId
+  };
+
+  const response = await fetch(options.tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Basic ' + Buffer.from(options.clientId + ':' + options.clientSecret).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: querystring.stringify(params),
+  });
+  if (!response.ok) {
+    throw new Error('Received HTTP error when refreshing tokens on OAuth2 server: ' + response.status);
+  }
+  const rBody = await response.json();
+
+  ctx.state.session.oauth2tokens = {
+    accessToken: rBody.access_token,
+    expires: Date.now() + (rBody.expires_in * 1000),
+    refreshToken: rBody.refresh_token,
+  };
+
+  return ctx.state.session.oauth2tokens;
+
+}
+
+function getAuthUrl(options: OAuth2Options, state: string): string {
+  return options.authorizeEndpoint + '?' + querystring.stringify({
+    response_type: 'code',
+    client_id: options.clientId,
+    redirect_uri: options.publicUri,
+    scope: options.scope.join(' '),
+    state
+  });
+
+}


### PR DESCRIPTION
After we add OAuth2 to our server, we lose the ability to browse around and see the hal-browser.

This new middleware fixes this by letting devs log into the API via OAuth